### PR TITLE
jsconfig for jsdocs

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,6 @@
+{
+	"compilerOptions": {
+		"checkJs": false
+	},
+	"include": ["**/*.js"]
+}


### PR DESCRIPTION
Adds the jsconfig.json to make jsdoc hover-annotations work in vscode