### PR TITLE
Fix json serialisationdeserialisation for class instances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,25 @@
+.gitignore# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+!.vscode/settings.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?

--- a/.todo
+++ b/.todo
@@ -4,3 +4,5 @@
 // This file should ideally be empty
 
 rm pw & ph
+
+add update changeSet to ResolutionSelect

--- a/app/scripts/lib/changeset.js
+++ b/app/scripts/lib/changeset.js
@@ -37,15 +37,17 @@ class ChangeSet {
 	}
 
 	undo() {
-		if (this.index <= 0) return;
+		if (this.index <= 0) return false;
 		this.index--;
 		this.restore(this.changeset[this.index]);
+		return true;
 	}
 
 	redo() {
-		if (this.index >= this.changeset.length - 1) return;
+		if (this.index >= this.changeset.length - 1) return false;
 		this.index++;
 		this.restore(this.changeset[this.index]);
+		return true;
 	}
 
 	restore(json) {

--- a/app/scripts/lib/controllers.js
+++ b/app/scripts/lib/controllers.js
@@ -267,7 +267,7 @@ class Controller extends Field {
 }
 
 /**
- * Controller that holds a value which can be serialised.
+ * Controller that holds a value which can be serialized.
  * @extends Controller
  * @example
  * // ValuedController gives back its value through a callback, that's where you tie it to the system.
@@ -321,25 +321,94 @@ class ValuedController extends Controller {
 	 * Gets the value for JSON serialization.
 	 * @returns {*}
 	 */
-	getValueForJSON() {
-		return this.value;
+	getValueForSerialization() {
+		if (this.value instanceof p5.Color)
+			return ValuedController.prepColorForSerialization(this.value);
+		if (this.value instanceof Vec2D)
+			return ValuedController.prepVec2DForSerialization(this.value);
+		if (this.value instanceof Vec3D)
+			return ValuedController.prepVec3DForSerialization(this.value);
+	}
+	/**
+	 * Restores value from serialized JSON form.
+	 * @param {*} value
+	 * @returns {void}
+	 */
+	restoreValue(serializedValue) {
+		this.setValue(serializedValue);
 	}
 
 	/**
-	 * Restores a serialized p5.Color object.
+	 * @static
+	 * @param {Vec2D} - Vec2D instance
+	 * @returns {Object}
+	 */
+	static prepVec2DForSerialization({ x, y }) {
+		return { type: 'Vec2D', x, y };
+	}
+	/**
+	 * @static
+	 * @param {Object} obj - serialized Vec2D
+	 * @returns {Vec2D}
+	 * @see restoreSerializedVec3D
+	 */
+	static restoreSerializedVec2D(obj) {
+		if (obj.type !== 'p5.Vec2D')
+			throw new Error('Object is not a serialized Vec2D.');
+		return new Vec2D(obj.x, obj.y);
+	}
+
+	/**
+	 * @static
+	 * @param {Vec3D} - Vec3D instance
+	 * @returns {Object}
+	 */
+	static prepVec3DForSerialization({ x, y, z }) {
+		return { type: 'Vec3D', x, y, z };
+	}
+	/**
+	 * @param {Object} obj - serialized Vec3D
+	 * @returns {Vec3D}
+	 * @see restoreSerializedVe23D
+	 */
+	static restoreSerializedVec3D(obj) {
+		if (obj.type !== 'p5.Vec3D')
+			throw new Error('Object is not a serialized Vec3D.');
+		return new Vec3D(obj.x, obj.y, obj.z);
+	}
+
+	/**
+	 * Preps a p5.Color for serialisation in JSON.
+	 * Strips any unneeded information.
+	 * @static
+	 * @param {p5.Color} color
+	 * @returns {Object}
+	 * @see restoreSerializedColor
+	 */
+	static prepColorForSerialization(color) {
+		if (!color instanceof p5.Color) {
+			throw new Error('color not a p5.Color instance.');
+		}
+		return {
+			type: 'p5.Color',
+			_array: color._array,
+		};
+	}
+	/**
+	 * @static
 	 * @param {Object} obj - The serialized object.
 	 * @returns {p5.Color} - The restored p5.Color object or the original object if not a color.
+	 * @see getColorForSerialization
 	 */
-	restoreSerializedP5Color(obj) {
-		if (
-			!obj._array ||
-			!Array.isArray(obj._array) ||
-			obj._array.length !== 4
-		) {
+	static restoreSerializedColor(obj) {
+		if (obj.type !== 'p5.Color')
 			throw new Error('Object is not a serialized p5.Color.');
-		}
+		push();
+		colorMode(RGB);
 		const col = color(0);
 		col._array = obj._array;
+		col._calculateLevels();
+		pop();
 		return col;
 	}
 }

--- a/app/scripts/lib/controllers.js
+++ b/app/scripts/lib/controllers.js
@@ -880,21 +880,23 @@ class Slider extends ValuedController {
 		this.minVal = minVal;
 		this.maxVal = maxVal;
 		this.defaultVal = defaultVal;
-		this.value = defaultVal;
 		this.stepSize = stepSize;
+		this.value = defaultVal;
 
-		const callback = event => {
+		this.controllerElement.elt.oninput = event => {
 			const value = parseFloat(event.srcElement.value);
 			valueCallback(this, value);
 		};
-		this.controllerElement.elt.onchange = callback;
-		this.controllerElement.elt.oninput = callback;
+		this.controllerElement.elt.onchange = event => {
+			const value = parseFloat(event.srcElement.value);
+			this.setValue(value);
+		};
 		valueCallback(this, defaultVal);
 		this.valueCallback = valueCallback;
 	}
 
 	setValue(value) {
-		this.value = value;
+		this.value = round(value / this.stepSize) * this.stepSize;
 		this.valueCallback(this, value);
 		this.controllerElement.value(value);
 		if (this.doUpdateChangeSet()) changeSet.save();

--- a/app/scripts/lib/controllers.js
+++ b/app/scripts/lib/controllers.js
@@ -324,6 +324,24 @@ class ValuedController extends Controller {
 	getValueForJSON() {
 		return this.value;
 	}
+
+	/**
+	 * Restores a serialized p5.Color object.
+	 * @param {Object} obj - The serialized object.
+	 * @returns {p5.Color} - The restored p5.Color object or the original object if not a color.
+	 */
+	restoreSerializedP5Color(obj) {
+		if (
+			!obj._array ||
+			!Array.isArray(obj._array) ||
+			obj._array.length !== 4
+		) {
+			throw new Error('Object is not a serialized p5.Color.');
+		}
+		const col = color(0);
+		col._array = obj._array;
+		return col;
+	}
 }
 
 /**
@@ -1046,6 +1064,16 @@ class XYSlider extends ValuedController {
  * @extends ValuedController
  */
 class ColourBoxes extends ValuedController {
+	/**
+	 * Constructor for ColourBoxes.
+	 * @param {GUI} gui
+	 * @param {string} name
+	 * @param {string} labelStr
+	 * @param {Array<p5.Color>} colours - Array of p5.Color objects.
+	 * @param {number} defaultIndex - Index of the default colour.
+	 * @param {function} valueCallback - Callback function to handle value changes.
+	 * @param {function} [setupCallback] - Optional setup callback function.
+	 */
 	constructor(
 		gui,
 		name,
@@ -1056,14 +1084,16 @@ class ColourBoxes extends ValuedController {
 		setupCallback = undefined
 	) {
 		super(gui, name, labelStr, setupCallback);
-
 		this.valueCallback = valueCallback;
-
 		this.createRadioFromColours(colours);
-
 		this.setValue(colours[defaultIndex]);
 	}
 
+	/**
+	 * Creates a radio button controller from an array of colours.
+	 * @param {Array<p5.Color>} colours - Array of p5.Color objects.
+	 * @returns {void}
+	 */
 	createRadioFromColours(colours) {
 		const isInit = this.controllerElement === undefined;
 		if (this.controllerElement) {
@@ -1096,8 +1126,12 @@ class ColourBoxes extends ValuedController {
 	}
 
 	setValue(colObj) {
-		if (!(colObj instanceof p5.Color))
-			throw new Error(colObj + ' is not a p5.Color.');
+		if (!(colObj instanceof p5.Color)) {
+			colObj = this.restoreSerializedP5Color(colObj);
+		}
+		if (!colObj) {
+			throw new Error(colObj + ' cannot be used as a p5.Color.');
+		}
 
 		const index = this.colours.findIndex(col =>
 			isArraysEqual(col.levels, colObj.levels)
@@ -1119,6 +1153,16 @@ class ColourBoxes extends ValuedController {
  * @extends ValuedController
  */
 class MultiColourBoxes extends ValuedController {
+	/**
+	 * Constructor for MultiColourBoxes.
+	 * @param {GUI} gui
+	 * @param {string} name
+	 * @param {string} labelStr
+	 * @param {Array<p5.Color>} colours - Array of p5.Color objects.
+	 * @param {Array<number>} defaultIndices - Indices of the default colours.
+	 * @param {function} valueCallback - Callback function to handle value changes.
+	 * @param {function} [setupCallback] - Optional setup callback function.
+	 */
 	constructor(
 		gui,
 		name,
@@ -1139,6 +1183,10 @@ class MultiColourBoxes extends ValuedController {
 		this.setValue(defaultCols);
 	}
 
+	/**
+	 * Sets the controller colours and creates checkboxes for each colour.
+	 * @returns {void}
+	 */
 	setControllerColours() {
 		if (this.controllerElement) {
 			this.controllerElement.remove();
@@ -1174,6 +1222,11 @@ class MultiColourBoxes extends ValuedController {
 		this.controllerElement = div;
 	}
 
+	/**
+	 * Sets the value from an array of indices.
+	 * @param {Array<number>} indices - Array of indices corresponding to selected colours.
+	 * @return {void}
+	 */
 	setValueFromIndices(indices) {
 		this.valueIndices = indices;
 		this.value = indices.map(i => this.colours[i]);
@@ -1211,6 +1264,15 @@ class MultiColourBoxes extends ValuedController {
  * @extends ValuedController
  */
 class Textbox extends ValuedController {
+	/**
+	 * Constructor for Textbox.
+	 * @param {GUI} gui - The GUI instance.
+	 * @param {string} name - The name of the controller.
+	 * @param {string} labelStr - The label for the controller.
+	 * @param {string} defaultVal - The default value for the textbox.
+	 * @param {function} valueCallback - Callback function for value changes.
+	 * @param {function} [setupCallback] - Optional setup callback.
+	 */
 	constructor(
 		gui,
 		name,
@@ -1256,6 +1318,14 @@ class Textbox extends ValuedController {
  * @extends ValuedController
  */
 class ResolutionTextboxes extends ValuedController {
+	/**
+	 * Constructor for ResolutionTextboxes.
+	 * @param {GUI} gui - The GUI instance.
+	 * @param {number} defW - Default width value.
+	 * @param {number} defH - Default height value.
+	 * @param {function} valueCallback - Callback function for value changes.
+	 * @param {function} [setupCallback] - Optional setup callback.
+	 */
 	constructor(gui, defW, defH, valueCallback, setupCallback = undefined) {
 		super(gui, 'resolutionTextboxes', undefined, setupCallback);
 		this.w = defW;
@@ -1306,6 +1376,12 @@ class ResolutionTextboxes extends ValuedController {
 		if (this.doUpdateChangeSet()) changeSet.save();
 	}
 
+	/**
+	 * Sets the width and height values directly.
+	 * @param {number} w - The width value.
+	 * @param {number} h - The height value.
+	 * @return {void}
+	 */
 	setValueOnlyDisplay(w, h) {
 		this.wBox.controllerElement.value(w);
 		this.hBox.controllerElement.value(h);
@@ -1317,6 +1393,15 @@ class ResolutionTextboxes extends ValuedController {
  * @extends ValuedController
  */
 class Textarea extends ValuedController {
+	/**
+	 * Constructor for Textarea.
+	 * @param {GUI} gui - The GUI instance.
+	 * @param {string} name - The name of the controller.
+	 * @param {string} labelStr - The label for the controller.
+	 * @param {string} defaultVal - The default value for the textarea.
+	 * @param {function} valueCallback - Callback function for value changes.
+	 * @param {function} [setupCallback] - Optional setup callback.
+	 */
 	constructor(
 		gui,
 		name,
@@ -1408,6 +1493,11 @@ class ColourTextArea extends Textarea {
 		this.displayColours(colours);
 	}
 
+	/**
+	 * Displays the colours in a div.
+	 * @param {Array<p5.Color>} colours - Array of p5.Color objects to display.
+	 * @returns {void}
+	 */
 	displayColours(colours) {
 		if (this.disp) this.disp.elt.remove();
 
@@ -1422,10 +1512,20 @@ class ColourTextArea extends Textarea {
 		}
 	}
 
+	/**
+	 * Converts an array of p5.Color objects to a comma-separated hex string.
+	 * @param {Array<p5.Color>} colours - Array of p5.Color objects.
+	 * @returns {string} - Comma-separated string of hex colours.
+	 */
 	static colourListToString(colours) {
 		return colours.map(c => colorToHexString(c).toUpperCase()).join(',');
 	}
 
+	/**
+	 * Parses a comma-separated string of hex colours into an array of p5.Color objects.
+	 * @param {string} str - Comma-separated string of hex colours.
+	 * @returns {Array<p5.Color>} - Array of p5.Color objects.
+	 */
 	static parseColourList(str) {
 		return str
 			.split(',')

--- a/app/scripts/lib/controllers.js
+++ b/app/scripts/lib/controllers.js
@@ -328,6 +328,8 @@ class ValuedController extends Controller {
 			return ValuedController.prepVec2DForSerialization(this.value);
 		if (this.value instanceof Vec3D)
 			return ValuedController.prepVec3DForSerialization(this.value);
+		// default (including number, string & boolean)
+		return this.value;
 	}
 	/**
 	 * Restores value from serialized JSON form.
@@ -353,7 +355,7 @@ class ValuedController extends Controller {
 	 * @see restoreSerializedVec3D
 	 */
 	static restoreSerializedVec2D(obj) {
-		if (obj.type !== 'p5.Vec2D')
+		if (obj.type !== 'Vec2D')
 			throw new Error('Object is not a serialized Vec2D.');
 		return new Vec2D(obj.x, obj.y);
 	}
@@ -878,6 +880,7 @@ class Slider extends ValuedController {
 		this.minVal = minVal;
 		this.maxVal = maxVal;
 		this.defaultVal = defaultVal;
+		this.value = defaultVal;
 		this.stepSize = stepSize;
 
 		const callback = event => {

--- a/app/scripts/lib/controllers.js
+++ b/app/scripts/lib/controllers.js
@@ -121,7 +121,7 @@ class Controller extends Field {
 
 	/**
 	 * Constructor for the Controller class.
-	 * @param {GUI} gui - The GUI instance this controller belongs to.
+	 * @param {GUIForP5} gui - The GUI instance this controller belongs to.
 	 * @param {string} name - The name of the controller.
 	 * @param {string} labelStr - The label text for the controller.
 	 * @param {function} [setupCallback] - Optional callback function for setup.
@@ -292,7 +292,7 @@ class ValuedController extends Controller {
 
 	/**
 	 * Constructor for ValuedController.
-	 * @param {GUI} gui
+	 * @param {GUIForP5} gui
 	 * @param {string} name
 	 * @param {string} labelStr
 	 * @param {function} [setupCallback]
@@ -351,7 +351,7 @@ class ValuedController extends Controller {
 class Button extends Controller {
 	/**
 	 * Constructor for Button.
-	 * @param {GUI} gui
+	 * @param {GUIForP5} gui
 	 * @param {string} name
 	 * @param {string} labelStr
 	 * @param {function} callback
@@ -410,7 +410,7 @@ class FileLoader extends Button {
 
 	/**
 	 * Constructor for FileLoader.
-	 * @param {GUI} gui
+	 * @param {GUIForP5} gui
 	 * @param {string} name
 	 * @param {string} fileType
 	 * @param {string} labelStr
@@ -460,7 +460,7 @@ class FileLoader extends Button {
 class TextFileLoader extends FileLoader {
 	/**
 	 * Constructor for TextFileLoader.
-	 * @param {GUI} gui
+	 * @param {GUIForP5} gui
 	 * @param {string} name
 	 * @param {string} labelStr
 	 * @param {function} valueCallback
@@ -487,7 +487,7 @@ class TextFileLoader extends FileLoader {
 class JSONFileLoader extends FileLoader {
 	/**
 	 * Constructor for JSONFileLoader.
-	 * @param {GUI} gui
+	 * @param {GUIForP5} gui
 	 * @param {string} name
 	 * @param {string} labelStr
 	 * @param {function} valueCallback
@@ -520,7 +520,7 @@ class ImageLoader extends FileLoader {
 
 	/**
 	 * Constructor for ImageLoader.
-	 * @param {GUI} gui
+	 * @param {GUIForP5} gui
 	 * @param {string} name
 	 * @param {string} labelStr
 	 * @param {function} valueCallback
@@ -557,7 +557,7 @@ class Toggle extends ValuedController {
 
 	/**
 	 * Constructor for Toggle.
-	 * @param {GUI} gui
+	 * @param {GUIForP5} gui
 	 * @param {string} name
 	 * @param {string} labelStr0
 	 * @param {string} labelStr1
@@ -647,7 +647,7 @@ class Select extends ValuedController {
 
 	/**
 	 * Constructor for Select.
-	 * @param {GUI} gui
+	 * @param {GUIForP5} gui
 	 * @param {string} name
 	 * @param {string} labelStr
 	 * @param {Array} options
@@ -1066,7 +1066,7 @@ class XYSlider extends ValuedController {
 class ColourBoxes extends ValuedController {
 	/**
 	 * Constructor for ColourBoxes.
-	 * @param {GUI} gui
+	 * @param {GUIForP5} gui
 	 * @param {string} name
 	 * @param {string} labelStr
 	 * @param {Array<p5.Color>} colours - Array of p5.Color objects.
@@ -1155,7 +1155,7 @@ class ColourBoxes extends ValuedController {
 class MultiColourBoxes extends ValuedController {
 	/**
 	 * Constructor for MultiColourBoxes.
-	 * @param {GUI} gui
+	 * @param {GUIForP5} gui
 	 * @param {string} name
 	 * @param {string} labelStr
 	 * @param {Array<p5.Color>} colours - Array of p5.Color objects.
@@ -1266,7 +1266,7 @@ class MultiColourBoxes extends ValuedController {
 class Textbox extends ValuedController {
 	/**
 	 * Constructor for Textbox.
-	 * @param {GUI} gui - The GUI instance.
+	 * @param {GUIForP5} gui - The GUI instance.
 	 * @param {string} name - The name of the controller.
 	 * @param {string} labelStr - The label for the controller.
 	 * @param {string} defaultVal - The default value for the textbox.
@@ -1320,7 +1320,7 @@ class Textbox extends ValuedController {
 class ResolutionTextboxes extends ValuedController {
 	/**
 	 * Constructor for ResolutionTextboxes.
-	 * @param {GUI} gui - The GUI instance.
+	 * @param {GUIForP5} gui - The GUI instance.
 	 * @param {number} defW - Default width value.
 	 * @param {number} defH - Default height value.
 	 * @param {function} valueCallback - Callback function for value changes.
@@ -1395,7 +1395,7 @@ class ResolutionTextboxes extends ValuedController {
 class Textarea extends ValuedController {
 	/**
 	 * Constructor for Textarea.
-	 * @param {GUI} gui - The GUI instance.
+	 * @param {GUIForP5} gui - The GUI instance.
 	 * @param {string} name - The name of the controller.
 	 * @param {string} labelStr - The label for the controller.
 	 * @param {string} defaultVal - The default value for the textarea.
@@ -1453,7 +1453,7 @@ class Textarea extends ValuedController {
 class ColourTextArea extends Textarea {
 	/**
 	 * ColourTextArea constructor.
-	 * @param {GUI} gui - The GUI instance.
+	 * @param {GUIForP5} gui - The GUI instance.
 	 * @param {string} name - The name of the controller.
 	 * @param {string} labelStr - The label for the controller.
 	 * @param {Array<p5.Color>} colours - The initial list of colours.

--- a/app/scripts/lib/gui.js
+++ b/app/scripts/lib/gui.js
@@ -343,10 +343,15 @@ class GUIForP5 {
 	getState() {
 		return this.controllers
 			.filter(controller => controller.value !== undefined)
-			.map(controller => ({
-				name: controller.name,
-				value: controller.getValueForJSON(),
-			}));
+			.map(controller => {
+				const serializable = {
+					name: controller.name,
+					value: controller.getValueForSerialization(),
+				};
+				// if (controller.die !== undefined)
+				// 	serializable.isDieActive = controller.die.isActive;
+				return serializable;
+			});
 	}
 
 	/**
@@ -355,12 +360,14 @@ class GUIForP5 {
 	 */
 	restoreState(state) {
 		Controller._doUpdateChangeSet = false;
-		for (let { name, value } of state) {
+		for (let { name, value, isDieActive } of state) {
 			const controller = gui.getController(name);
 			if (controller.setValue && value !== undefined) {
 				value = restoreSerializedP5Color(value);
 				value = restoreSerializedVec2D(value);
 				controller.setValue(value);
+				// if (isDieActive !== undefined)
+				// 	controller.die.setActive(isDieActive);
 			}
 		}
 		Controller._doUpdateChangeSet = true;

--- a/app/scripts/lib/util.js
+++ b/app/scripts/lib/util.js
@@ -2,43 +2,6 @@
  * @fileoverview Utility helper functions used throughout the project.
  */
 
-// ---------------------- RESTORING SERIALISED OBJS -----------------------
-
-/**
- * Convert a serialised p5.Color back into a live {@link p5.Color} instance.
- * @param {object} obj Serialised colour object.
- * @returns {p5.Color|object}
- */
-function restoreSerializedP5Color(obj) {
-	if (!(obj.levels && obj.mode)) return obj;
-	push();
-	colorMode(RGB);
-	const col = color(obj.levels);
-	pop();
-	return col;
-}
-
-/**
- * Convert a plain object to a {@link Vec3D} if it contains x, y, and z.
- * @param {object} obj Potentially serialised vector.
- * @returns {Vec3D|object}
- */
-function restoreSerializedVec3D(obj) {
-	// always use before Vec2D version when used in combination
-	if ([obj.x, obj.y, obj.z].some(v => v === undefined)) return obj;
-	return new Vec3D(obj.x, obj.y, obj.z);
-}
-
-/**
- * Convert a plain object to a {@link Vec2D} if it contains x and y.
- * @param {object} obj Potentially serialised vector.
- * @returns {Vec2D|object}
- */
-function restoreSerializedVec2D(obj) {
-	if ([obj.x, obj.y].some(v => v === undefined)) return obj;
-	return new Vec2D(obj.x, obj.y);
-}
-
 // ----------------------------- DRAWING ------------------------------
 
 /**


### PR DESCRIPTION
**Description**
Moves the handling of serialisation and deserialising (from and to JSON) from `GUIForP5` to `ValuedController` using static (de)serialization methods.

**Checklist**
*Thank you for contributing to p5Catalyst. Before submitting this PR into the main branch, please sure:*
- [x] *You have tested the feature*
- [x] *The code doesn't cause any errors*

Solves #53, #54, #55 and #7.